### PR TITLE
#19 Fix lodash dependency import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { Todo } from './Todo';
 


### PR DESCRIPTION
Forgot about this one. When using import { uniqueId } from 'lodash'; we are actually importing the whole lodash library. So, better to use import uniqueId from 'lodash/uniqueId'; instead